### PR TITLE
Update env to python3.11

### DIFF
--- a/zypperoni
+++ b/zypperoni
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3.11
 #
 # SPDX-License-Identifier: GPL-3.0-only
 #


### PR DESCRIPTION
openSUSE 15.6 has python3 linked to version 3.6.5, and zypperoni needs 3.11. 

Even if you install the python311 package it still doesn't work. Therefore I have changed env to call python3.11 directly.